### PR TITLE
[main-131] surface errors related to onRoomStart, onPlayerJoin, and onPlayerQuit by logging them

### DIFF
--- a/src/setupServer.js
+++ b/src/setupServer.js
@@ -40,18 +40,20 @@ module.exports = {
     app.use(express.json());
 
     app.post('/player', (_, res) => {
+      let boardGameContender = JSON.parse(JSON.stringify(boardGame));
       const username = `user_${boardGame.playerIdCounter}`;
       const id = `id_${boardGame.playerIdCounter}`;
       const player = {
         id, username,
       };
-      boardGame.playerIdCounter += 1;
-      boardGame.players.push(player);
-      boardGame = applyBoardGameResult(
-        boardGame,
-        backendModule.onPlayerJoin(player, filterBoardGame(boardGame)),
+      boardGameContender.playerIdCounter += 1;
+      boardGameContender.players.push(player);
+      boardGameContender = applyBoardGameResult(
+        boardGameContender,
+        backendModule.onPlayerJoin(player, filterBoardGame(boardGameContender)),
       );
-      io.sockets.emit('stateChanged', boardGame);
+      io.sockets.emit('stateChanged', boardGameContender);
+      boardGame = boardGameContender;
       res.status(StatusCodes.OK).json(player);
     });
 
@@ -62,27 +64,30 @@ module.exports = {
         res.status(StatusCodes.BAD_REQUEST).json({ message: `${id} is not in the board game` });
         return;
       }
-      boardGame = removePlayerById(id, boardGame);
-      boardGame = applyBoardGameResult(
-        boardGame,
-        backendModule.onPlayerQuit(player, filterBoardGame(boardGame)),
+      let boardGameContender = JSON.parse(JSON.stringify(boardGame));
+      boardGameContender = removePlayerById(id, boardGameContender);
+      boardGameContender = applyBoardGameResult(
+        boardGameContender,
+        backendModule.onPlayerQuit(player, filterBoardGame(boardGameContender)),
       );
-      io.sockets.emit('stateChanged', boardGame);
+      io.sockets.emit('stateChanged', boardGameContender);
+      boardGame = boardGameContender;
       res.sendStatus(StatusCodes.OK);
     });
 
     app.post('/player/:id/move', (req, res) => {
       const { id } = req.params;
-      const player = getPlayerById(id, boardGame);
+      let boardGameContender = JSON.parse(JSON.stringify(boardGame));
+      const player = getPlayerById(id, boardGameContender);
       if (player === undefined) {
         res.status(StatusCodes.BAD_REQUEST).json({ message: `${id} is not in the board game` });
         return;
       }
       const move = req.body;
       try {
-        boardGame = applyBoardGameResult(
-          boardGame,
-          backendModule.onPlayerMove(player, move, filterBoardGame(boardGame)),
+        boardGameContender = applyBoardGameResult(
+          boardGameContender,
+          backendModule.onPlayerMove(player, move, filterBoardGame(boardGameContender)),
         );
       } catch (err) {
         res.status(StatusCodes.BAD_REQUEST).json({
@@ -94,7 +99,8 @@ module.exports = {
         });
         return;
       }
-      io.sockets.emit('stateChanged', boardGame);
+      io.sockets.emit('stateChanged', boardGameContender);
+      boardGame = boardGameContender;
       res.sendStatus(StatusCodes.OK);
     });
 
@@ -105,6 +111,11 @@ module.exports = {
     app.delete('/state', (req, res) => {
       boardGame = newBoardGame(backendModule);
       res.sendStatus(StatusCodes.OK);
+    });
+
+    app.use((err, req, res) => {
+      console.error(err);
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err);
     });
 
     const server = httpServer.listen(apiPort);

--- a/src/setupServer.js
+++ b/src/setupServer.js
@@ -114,6 +114,8 @@ module.exports = {
     });
 
     app.use((err, req, res) => {
+      // log error for developers so they can see any potential errors on the backendModule for
+      // functions related to onRoomStart, onPlayerJoin, and onPlayerQuit
       console.error(err);
       res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err);
     });


### PR DESCRIPTION
surfaces error in terminal. for example:
```
[0] Error: onRoomstart force failure
[0]     at Object.onPlayerQuit (/home/kevin/github/personal/turnbasedgames/runner/test_app/index.js:36:11)
[0]     at /home/kevin/github/personal/turnbasedgames/runner/src/setupServer.js:71:23
[0]     at Layer.handle [as handle_request] (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/layer.js:95:5)
[0]     at next (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/route.js:144:13)
[0]     at Route.dispatch (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/route.js:114:3)
[0]     at Layer.handle [as handle_request] (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/layer.js:95:5)
[0]     at /home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/index.js:284:15
[0]     at param (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/index.js:365:14)
[0]     at param (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/index.js:376:14)
[0]     at Function.process_params (/home/kevin/github/personal/turnbasedgames/runner/node_modules/express/lib/router/index.js:421:3)
```